### PR TITLE
Set custom User-Agent

### DIFF
--- a/macos/Classes/WebView.swift
+++ b/macos/Classes/WebView.swift
@@ -27,6 +27,7 @@ public class InAppWebViewMacos: WKWebView
 
   init(frame: CGRect, configuration: WKWebViewConfiguration, channel: FlutterMethodChannel?) {
     super.init(frame: frame, configuration: configuration)
+    super.customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15"
     self.channel = channel
 //    uiDelegate = self
 //    navigationDelegate = self


### PR DESCRIPTION
 It is needed for being able to access some web pages
 such as [YouTube Music](https://music.youtube.com/).

 The UA string is based on:
 `HTTP_USER_AGENT` of Safari running on my environment.