### PR TITLE
Add method handler of "reload" and "clearCache"

### DIFF
--- a/macos/Classes/MethodHandler.swift
+++ b/macos/Classes/MethodHandler.swift
@@ -86,6 +86,10 @@ public class InAppWebViewMacosMethodHandler: FlutterMethodCallDelegate {
         allowingReadAccessTo: allowingReadAccessToURL)
       result(true)
 
+    case "clearCache":
+      controller!.webView!.clearCache()
+      result("success")
+
     default:
       result(FlutterMethodNotImplemented)
     }

--- a/macos/Classes/MethodHandler.swift
+++ b/macos/Classes/MethodHandler.swift
@@ -73,6 +73,19 @@ public class InAppWebViewMacosMethodHandler: FlutterMethodCallDelegate {
       let url = controller!.webView!.getOriginalUrl()
       result(url?.baseURL)
 
+    case "reload":
+      let urlRequest = arguments!["urlRequest"] as! [String: Any?]
+      let allowingReadAccessTo = arguments!["allowingReadAccessTo"] as? String
+      var allowingReadAccessToURL: URL? = nil
+      if let allowingReadAccessTo = allowingReadAccessTo {
+        allowingReadAccessToURL = URL(string: allowingReadAccessTo)
+      }
+      Thread.sleep(forTimeInterval: 1) // FIXME: same as above
+      controller!.webView!.loadUrl(
+        urlRequest: URLRequest.init(fromPluginMap: urlRequest),
+        allowingReadAccessTo: allowingReadAccessToURL)
+      result(true)
+
     default:
       result(FlutterMethodNotImplemented)
     }


### PR DESCRIPTION
⚠️ Just a workaround, no warranty if you use

This PR makes to be able to;
* Reload WebView (486a3343c4cc57eb4a1c9cc36763b224232b2777)
* Clear stored cookies (ee6eb5c798c0c3cf14d1aa6f3ad6253a6d9bc982)

App usage sample is below;

```diff
diff --git a/lib/main.dart b/lib/main.dart
index 7a07b1b..cbb39eb 100644
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,6 +82,20 @@ class _MyMusicAppState extends State<MyMusicApp> with WindowListener {
         appBar: (_isAppbarHidden)
             ? AppBar(
                 title: const Text("Flutter Music App"),
+                actions: <Widget>[
+                  IconButton(
+                    icon: const Icon(Icons.delete),
+                    onPressed: () {
+                      _controller!.clearCache();
+                    },
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.refresh),
+                    onPressed: () {
+                      _controller!.reload();
+                    },
+                  ),
+                ],
               )
             : const EmptyAppBar(),
         body: Center(
```